### PR TITLE
fix ndk build problems on eclipse and unsatisfied link error for both sample projects

### DIFF
--- a/samples/LiquidFun-EyeCandy/proj.android/.cproject
+++ b/samples/LiquidFun-EyeCandy/proj.android/.cproject
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="0.1230402123">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="0.1230402123" moduleId="org.eclipse.cdt.core.settings" name="Default">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.VCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="0.1230402123" name="Default" parent="org.eclipse.cdt.build.core.prefbase.cfg">
+					<folderInfo id="0.1230402123." name="/" resourcePath="">
+						<toolChain id="org.eclipse.cdt.build.core.prefbase.toolchain.1911072326" name="No ToolChain" resourceTypeBasedDiscovery="false" superClass="org.eclipse.cdt.build.core.prefbase.toolchain">
+							<targetPlatform id="org.eclipse.cdt.build.core.prefbase.toolchain.1911072326.2087917918" name=""/>
+							<builder arguments="${ProjDirPath}/build_native.py" buildPath="${ProjDirPath}" command="python" id="org.eclipse.cdt.build.core.settings.default.builder.1038735572" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="org.eclipse.cdt.build.core.settings.default.builder">
+								<outputEntries>
+									<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="outputPath" name=""/>
+								</outputEntries>
+							</builder>
+							<tool id="org.eclipse.cdt.build.core.settings.holder.libs.547532631" name="holder for library settings" superClass="org.eclipse.cdt.build.core.settings.holder.libs"/>
+							<tool id="org.eclipse.cdt.build.core.settings.holder.1481118451" name="Assembly" superClass="org.eclipse.cdt.build.core.settings.holder">
+								<option id="org.eclipse.cdt.build.core.settings.holder.incpaths.990682174" name="Include Paths" superClass="org.eclipse.cdt.build.core.settings.holder.incpaths" valueType="includePath">
+									<listOptionValue builtIn="false" value="C:/eclipse/android-ndk-r8e/sources/android/native_app_glue"/>
+									<listOptionValue builtIn="false" value="C:/eclipse/android-ndk-r8e/platforms/android-18/arch-arm/usr/include"/>
+									<listOptionValue builtIn="false" value="C:/eclipse/android-ndk-r8e/sources/cxx-stl/gnu-libstdc++/4.8/include"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/2d"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/physics"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/base"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/math/kazmath"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/ui"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/network"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/audio/include"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/editor-support"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/extensions"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/external"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/external/chipmunk/include/chipmunk"/>
+								</option>
+								<option id="org.eclipse.cdt.build.core.settings.holder.symbols.387417389" name="Symbols" superClass="org.eclipse.cdt.build.core.settings.holder.symbols" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="CC_TARGET_PLATFORM=CC_PLATFORM_ANDROID"/>
+									<listOptionValue builtIn="false" value="CC_DLL"/>
+								</option>
+								<inputType id="org.eclipse.cdt.build.core.settings.holder.inType.992559344" languageId="org.eclipse.cdt.core.assembly" languageName="Assembly" sourceContentType="org.eclipse.cdt.core.asmSource" superClass="org.eclipse.cdt.build.core.settings.holder.inType"/>
+							</tool>
+							<tool id="org.eclipse.cdt.build.core.settings.holder.429561268" name="GNU C++" superClass="org.eclipse.cdt.build.core.settings.holder">
+								<option id="org.eclipse.cdt.build.core.settings.holder.incpaths.1008860290" name="Include Paths" superClass="org.eclipse.cdt.build.core.settings.holder.incpaths" valueType="includePath">
+									<listOptionValue builtIn="false" value="C:/eclipse/android-ndk-r8e/sources/android/native_app_glue"/>
+									<listOptionValue builtIn="false" value="C:/eclipse/android-ndk-r8e/platforms/android-18/arch-arm/usr/include"/>
+									<listOptionValue builtIn="false" value="C:/eclipse/android-ndk-r8e/sources/cxx-stl/gnu-libstdc++/4.8/include"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/2d"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/physics"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/base"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/math/kazmath"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/ui"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/network"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/audio/include"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/editor-support"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/extensions"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/external"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/external/chipmunk/include/chipmunk"/>
+								</option>
+								<option id="org.eclipse.cdt.build.core.settings.holder.symbols.1728671637" name="Symbols" superClass="org.eclipse.cdt.build.core.settings.holder.symbols" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="CC_TARGET_PLATFORM=CC_PLATFORM_ANDROID"/>
+									<listOptionValue builtIn="false" value="CC_DLL"/>
+								</option>
+								<inputType id="org.eclipse.cdt.build.core.settings.holder.inType.788524757" languageId="org.eclipse.cdt.core.g++" languageName="GNU C++" sourceContentType="org.eclipse.cdt.core.cxxSource,org.eclipse.cdt.core.cxxHeader" superClass="org.eclipse.cdt.build.core.settings.holder.inType"/>
+							</tool>
+							<tool id="org.eclipse.cdt.build.core.settings.holder.795443271" name="GNU C" superClass="org.eclipse.cdt.build.core.settings.holder">
+								<option id="org.eclipse.cdt.build.core.settings.holder.incpaths.315092538" name="Include Paths" superClass="org.eclipse.cdt.build.core.settings.holder.incpaths" valueType="includePath">
+									<listOptionValue builtIn="false" value="C:/eclipse/android-ndk-r8e/sources/android/native_app_glue"/>
+									<listOptionValue builtIn="false" value="C:/eclipse/android-ndk-r8e/platforms/android-18/arch-arm/usr/include"/>
+									<listOptionValue builtIn="false" value="C:/eclipse/android-ndk-r8e/sources/cxx-stl/gnu-libstdc++/4.8/include"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/2d"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/physics"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/base"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/math/kazmath"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/ui"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/network"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/audio/include"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/editor-support"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/extensions"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/external"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/external/chipmunk/include/chipmunk"/>
+								</option>
+								<option id="org.eclipse.cdt.build.core.settings.holder.symbols.706119994" name="Symbols" superClass="org.eclipse.cdt.build.core.settings.holder.symbols" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="CC_TARGET_PLATFORM=CC_PLATFORM_ANDROID"/>
+									<listOptionValue builtIn="false" value="CC_DLL"/>
+								</option>
+								<inputType id="org.eclipse.cdt.build.core.settings.holder.inType.1846971482" languageId="org.eclipse.cdt.core.gcc" languageName="GNU C" sourceContentType="org.eclipse.cdt.core.cSource,org.eclipse.cdt.core.cHeader" superClass="org.eclipse.cdt.build.core.settings.holder.inType"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry excluding="Classes|cocos2d" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="Classes"/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="0.1230402123">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="LiquidFun-Testbed.null.31159645" name="LiquidFun-Testbed"/>
+	</storageModule>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Default">
+			<resource resourceType="PROJECT" workspacePath="/LiquidFun-Testbed"/>
+		</configuration>
+	</storageModule>
+</cproject>

--- a/samples/LiquidFun-EyeCandy/proj.android/.project
+++ b/samples/LiquidFun-EyeCandy/proj.android/.project
@@ -3,6 +3,7 @@
 	<name>LiquidFun_EyeCandy</name>
 	<comment></comment>
 	<projects>
+		<project>libcocos2dx</project>
 	</projects>
 	<buildSpec>
 		<buildCommand>
@@ -18,6 +19,72 @@
 		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
 			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+				<dictionary>
+					<key>?children?</key>
+					<value>?name?=outputEntries\|?children?=?name?=entry\\\\\\\|\\\|\||</value>
+				</dictionary>
+				<dictionary>
+					<key>?name?</key>
+					<value></value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.append_environment</key>
+					<value>true</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.autoBuildTarget</key>
+					<value>all</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.buildArguments</key>
+					<value>${ProjDirPath}/build_native.py</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.buildCommand</key>
+					<value>python</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.buildLocation</key>
+					<value>${ProjDirPath}</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.cleanBuildTarget</key>
+					<value>clean</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.contents</key>
+					<value>org.eclipse.cdt.make.core.activeConfigSettings</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.enableAutoBuild</key>
+					<value>false</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.enableCleanBuild</key>
+					<value>true</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.enableFullBuild</key>
+					<value>true</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.fullBuildTarget</key>
+					<value>all</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.stopOnError</key>
+					<value>true</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.useDefaultBuildCmd</key>
+					<value>false</value>
+				</dictionary>
 			</arguments>
 		</buildCommand>
 		<buildCommand>

--- a/samples/LiquidFun-EyeCandy/proj.android/AndroidManifest.xml
+++ b/samples/LiquidFun-EyeCandy/proj.android/AndroidManifest.xml
@@ -11,15 +11,15 @@
                  android:icon="@drawable/icon">
 
 
+        <!-- Tell NativeActivity the name of our .so -->
+        <meta-data android:name="android.app.lib_name"
+                  android:value="liquidfun_eyecandy" />
+            
         <activity android:name="org.cocos2dx.liquidfun_eyecandy.AppActivity"
                   android:label="@string/app_name"
                   android:screenOrientation="landscape"
                   android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
                   android:configChanges="orientation">
-
-            <!-- Tell NativeActivity the name of our .so -->
-            <meta-data android:name="android.app.lib_name"
-                       android:value="liquidfun_eyecandy" />
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/samples/LiquidFun-Testbed/proj.android/.cproject
+++ b/samples/LiquidFun-Testbed/proj.android/.cproject
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="0.1230402123">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="0.1230402123" moduleId="org.eclipse.cdt.core.settings" name="Default">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.VCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="0.1230402123" name="Default" parent="org.eclipse.cdt.build.core.prefbase.cfg">
+					<folderInfo id="0.1230402123." name="/" resourcePath="">
+						<toolChain id="org.eclipse.cdt.build.core.prefbase.toolchain.1911072326" name="No ToolChain" resourceTypeBasedDiscovery="false" superClass="org.eclipse.cdt.build.core.prefbase.toolchain">
+							<targetPlatform id="org.eclipse.cdt.build.core.prefbase.toolchain.1911072326.2087917918" name=""/>
+							<builder arguments="${ProjDirPath}/build_native.py" buildPath="${ProjDirPath}" command="python" id="org.eclipse.cdt.build.core.settings.default.builder.1038735572" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="org.eclipse.cdt.build.core.settings.default.builder">
+								<outputEntries>
+									<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="outputPath" name=""/>
+								</outputEntries>
+							</builder>
+							<tool id="org.eclipse.cdt.build.core.settings.holder.libs.547532631" name="holder for library settings" superClass="org.eclipse.cdt.build.core.settings.holder.libs"/>
+							<tool id="org.eclipse.cdt.build.core.settings.holder.1481118451" name="Assembly" superClass="org.eclipse.cdt.build.core.settings.holder">
+								<option id="org.eclipse.cdt.build.core.settings.holder.incpaths.990682174" name="Include Paths" superClass="org.eclipse.cdt.build.core.settings.holder.incpaths" valueType="includePath">
+									<listOptionValue builtIn="false" value="C:/eclipse/android-ndk-r8e/sources/android/native_app_glue"/>
+									<listOptionValue builtIn="false" value="C:/eclipse/android-ndk-r8e/platforms/android-18/arch-arm/usr/include"/>
+									<listOptionValue builtIn="false" value="C:/eclipse/android-ndk-r8e/sources/cxx-stl/gnu-libstdc++/4.8/include"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/2d"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/physics"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/base"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/math/kazmath"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/ui"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/network"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/audio/include"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/editor-support"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/extensions"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/external"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/external/chipmunk/include/chipmunk"/>
+								</option>
+								<option id="org.eclipse.cdt.build.core.settings.holder.symbols.387417389" name="Symbols" superClass="org.eclipse.cdt.build.core.settings.holder.symbols" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="CC_TARGET_PLATFORM=CC_PLATFORM_ANDROID"/>
+									<listOptionValue builtIn="false" value="CC_DLL"/>
+								</option>
+								<inputType id="org.eclipse.cdt.build.core.settings.holder.inType.992559344" languageId="org.eclipse.cdt.core.assembly" languageName="Assembly" sourceContentType="org.eclipse.cdt.core.asmSource" superClass="org.eclipse.cdt.build.core.settings.holder.inType"/>
+							</tool>
+							<tool id="org.eclipse.cdt.build.core.settings.holder.429561268" name="GNU C++" superClass="org.eclipse.cdt.build.core.settings.holder">
+								<option id="org.eclipse.cdt.build.core.settings.holder.incpaths.1008860290" name="Include Paths" superClass="org.eclipse.cdt.build.core.settings.holder.incpaths" valueType="includePath">
+									<listOptionValue builtIn="false" value="C:/eclipse/android-ndk-r8e/sources/android/native_app_glue"/>
+									<listOptionValue builtIn="false" value="C:/eclipse/android-ndk-r8e/platforms/android-18/arch-arm/usr/include"/>
+									<listOptionValue builtIn="false" value="C:/eclipse/android-ndk-r8e/sources/cxx-stl/gnu-libstdc++/4.8/include"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/2d"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/physics"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/base"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/math/kazmath"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/ui"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/network"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/audio/include"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/editor-support"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/extensions"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/external"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/external/chipmunk/include/chipmunk"/>
+								</option>
+								<option id="org.eclipse.cdt.build.core.settings.holder.symbols.1728671637" name="Symbols" superClass="org.eclipse.cdt.build.core.settings.holder.symbols" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="CC_TARGET_PLATFORM=CC_PLATFORM_ANDROID"/>
+									<listOptionValue builtIn="false" value="CC_DLL"/>
+								</option>
+								<inputType id="org.eclipse.cdt.build.core.settings.holder.inType.788524757" languageId="org.eclipse.cdt.core.g++" languageName="GNU C++" sourceContentType="org.eclipse.cdt.core.cxxSource,org.eclipse.cdt.core.cxxHeader" superClass="org.eclipse.cdt.build.core.settings.holder.inType"/>
+							</tool>
+							<tool id="org.eclipse.cdt.build.core.settings.holder.795443271" name="GNU C" superClass="org.eclipse.cdt.build.core.settings.holder">
+								<option id="org.eclipse.cdt.build.core.settings.holder.incpaths.315092538" name="Include Paths" superClass="org.eclipse.cdt.build.core.settings.holder.incpaths" valueType="includePath">
+									<listOptionValue builtIn="false" value="C:/eclipse/android-ndk-r8e/sources/android/native_app_glue"/>
+									<listOptionValue builtIn="false" value="C:/eclipse/android-ndk-r8e/platforms/android-18/arch-arm/usr/include"/>
+									<listOptionValue builtIn="false" value="C:/eclipse/android-ndk-r8e/sources/cxx-stl/gnu-libstdc++/4.8/include"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/2d"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/physics"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/base"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/math/kazmath"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/ui"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/network"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/audio/include"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/cocos/editor-support"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/extensions"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/external"/>
+									<listOptionValue builtIn="false" value="C:/Development/GitHub/LiquidFun-Testbed/samples/LiquidFun-Testbed/cocos2d/external/chipmunk/include/chipmunk"/>
+								</option>
+								<option id="org.eclipse.cdt.build.core.settings.holder.symbols.706119994" name="Symbols" superClass="org.eclipse.cdt.build.core.settings.holder.symbols" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="CC_TARGET_PLATFORM=CC_PLATFORM_ANDROID"/>
+									<listOptionValue builtIn="false" value="CC_DLL"/>
+								</option>
+								<inputType id="org.eclipse.cdt.build.core.settings.holder.inType.1846971482" languageId="org.eclipse.cdt.core.gcc" languageName="GNU C" sourceContentType="org.eclipse.cdt.core.cSource,org.eclipse.cdt.core.cHeader" superClass="org.eclipse.cdt.build.core.settings.holder.inType"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry excluding="Classes|cocos2d" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="Classes"/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="0.1230402123">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="LiquidFun-Testbed.null.31159645" name="LiquidFun-Testbed"/>
+	</storageModule>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Default">
+			<resource resourceType="PROJECT" workspacePath="/LiquidFun-Testbed"/>
+		</configuration>
+	</storageModule>
+</cproject>

--- a/samples/LiquidFun-Testbed/proj.android/.project
+++ b/samples/LiquidFun-Testbed/proj.android/.project
@@ -3,6 +3,7 @@
 	<name>LiquidFun-TestBed</name>
 	<comment></comment>
 	<projects>
+		<project>libcocos2dx</project>
 	</projects>
 	<buildSpec>
 		<buildCommand>
@@ -18,6 +19,72 @@
 		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
 			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+				<dictionary>
+					<key>?children?</key>
+					<value>?name?=outputEntries\|?children?=?name?=entry\\\\\\\|\\\|\||</value>
+				</dictionary>
+				<dictionary>
+					<key>?name?</key>
+					<value></value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.append_environment</key>
+					<value>true</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.autoBuildTarget</key>
+					<value>all</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.buildArguments</key>
+					<value>${ProjDirPath}/build_native.py</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.buildCommand</key>
+					<value>python</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.buildLocation</key>
+					<value>${ProjDirPath}</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.cleanBuildTarget</key>
+					<value>clean</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.contents</key>
+					<value>org.eclipse.cdt.make.core.activeConfigSettings</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.enableAutoBuild</key>
+					<value>false</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.enableCleanBuild</key>
+					<value>true</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.enableFullBuild</key>
+					<value>true</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.fullBuildTarget</key>
+					<value>all</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.stopOnError</key>
+					<value>true</value>
+				</dictionary>
+				<dictionary>
+					<key>org.eclipse.cdt.make.core.useDefaultBuildCmd</key>
+					<value>false</value>
+				</dictionary>
 			</arguments>
 		</buildCommand>
 		<buildCommand>

--- a/samples/LiquidFun-Testbed/proj.android/AndroidManifest.xml
+++ b/samples/LiquidFun-Testbed/proj.android/AndroidManifest.xml
@@ -10,16 +10,15 @@
     <application android:label="@string/app_name"
                  android:icon="@drawable/icon">
 
+        <!-- Tell NativeActivity the name of our .so -->
+        <meta-data android:name="android.app.lib_name"
+                  android:value="liquidfun_testbed" />
 
         <activity android:name="org.cocos2dx.liquidfun_testbed.AppActivity"
                   android:label="@string/app_name"
                   android:screenOrientation="landscape"
                   android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
                   android:configChanges="orientation">
-
-            <!-- Tell NativeActivity the name of our .so -->
-            <meta-data android:name="android.app.lib_name"
-                       android:value="liquidfun_testbed" />
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
The sample projects doesn't build the ndk files in eclipse, so I:
1. configure the build chain (.project and .cproject)
2. fix the unsatisfied link error: for the Cocos2dxActivity to load the lib, the meta-data "android.app.lib_name" need to be placed directly under <application> tag in AndroidManifest.xml, not <activity> tag
